### PR TITLE
Add docs for CJA Audit Log APIs

### DIFF
--- a/src/pages/endpoints/auditlogs/index.md
+++ b/src/pages/endpoints/auditlogs/index.md
@@ -1,0 +1,328 @@
+---
+keywords:
+  - Experience Platform
+  - API Documentation
+  - JavaScript
+title: Audit Logs
+description: Get a list of audit logs using the API.
+---
+
+# CJA Audit Logs
+
+The Audit Log API allows you to retrieve a list of audit log records using a GET or POST method through Adobe I/O. The GET endpoint provides a way to add filters through query string parameters. The POST endpoint offers greater flexibility to your search criteria.
+
+## Get Audit Logs
+
+The GET endpoint is designed for use when few or no filters are needed. If filters are included by adding query string parameters, each query string parameter will filter the list of audit logs using an 'AND' condition.
+
+`GET https://cja.adobe.io/auditlogs/api/v1/auditlogs`
+
+Hitting this endpoint with no query string parameters will return the last 1000 audit log records in descending order. To filter the audit log records, please reference the list of available query string parameters.
+
+
+### Query String Parameters
+| Query String | Type | Description | Possible Values|
+| --- | --- | ---------- | ----- |
+| startDate | String | Begin date range. If startDate is set, endDate must also be defined. | 2021-01-01T00:00:00-07 |
+| endDate | String | End date range. If endDate is set, startDate must also be defined. | 2021-02-01T00:00:00-07 |
+| action | Enum | The type of action a user or system can make. | CREATE, EDIT, DELETE, LOGIN_FAILED, LOGIN_SUCCESSFUL, API_REQUEST |
+| component | Enum | The type of component. | CALCULATED_METRIC, CONNECTION, DATA_GROUP, DATA_VIEW, DATE_RANGE, FILTER, MOBILE, PROJECT, REPORT, SCHEDULED_PROJECT |
+| componentId | String | The id of the component. | -- |
+| userType | Enum | The type of user. | IMS, OKTA |
+| userId | String | The id of the user. | -- |
+| userEmail | String | The email address of the user. | User defined |
+| description | String | The description of the audit log. | User defined |
+| pageSize | Integer | Number of results per page. If left null, the default size will be set to 100. | 10 |
+| pageNumber | Integer | Page number (base 0 - first page is "0") | 0 |
+
+### Example : Get audit logs with no filters
+
+Request:
+`GET https://cja.adobe.io/auditlogs/api/v1/auditlogs`
+
+Response:
+
+```
+{
+  "content": [
+    {
+      "id": "61573795d9409a491f1a9604",
+      "dateCreated": "2021-10-01T16:30:13.377+00:00",
+      "action": "CREATE",
+      "description": "Creating scheduled job: e1efbf6c-d483-408e-b033-3045e594b656",
+      "imsOrgId": "4E9432245BC7C44B0A494037@AdobeOrg",
+      "user": {
+        "id": "434F42A85501C8190A4C86DE@AdobeID",
+        "idType": "IMS",
+        "name": null,
+        "email": null
+      },
+      "component": {
+        "id": "e1efbf6c-d483-408e-b033-3045e594b656",
+        "idType": "SCHEDULED_PROJECT",
+        "name": ""
+      }
+    },
+    {
+      "id": "615735e8d9409a491f1a9603",
+      "dateCreated": "2021-10-01T16:23:04.821+00:00",
+      "action": "DELETE",
+      "description": "Deleting scheduled job: 7baaf2f8-209a-4886-9619-30f3054884ce",
+      "imsOrgId": "4E9432245BC7C44B0A494037@AdobeOrg",
+      "user": {
+        "id": "06257AF96137B9990A494018@fd6f6f286137b98d494230.e",
+        "idType": "IMS",
+        "name": null,
+        "email": null
+      },
+      "component": {
+        "id": "7baaf2f8-209a-4886-9619-30f3054884ce",
+        "idType": "SCHEDULED_PROJECT",
+        "name": "EOW reporting"
+      }
+    }
+  ],
+  "pageable": {
+    "sort": {
+      "sorted": false,
+      "unsorted": true,
+      "empty": true
+    },
+    "offset": 0,
+    "pageNumber": 0,
+    "pageSize": 2,
+    "paged": true,
+    "unpaged": false
+  },
+  "last": false,
+  "totalElements": 1946,
+  "totalPages": 973,
+  "size": 2,
+  "number": 0,
+  "sort": {
+    "sorted": false,
+    "unsorted": true,
+    "empty": true
+  },
+  "numberOfElements": 2,
+  "first": true,
+  "empty": false
+}
+```
+
+### Example : Get audit logs with filters applied
+
+Request:
+
+```
+https://cja.adobe.io/auditlogs/api/v1/auditlogs?startDate=2021-08-01T00%3A00%3A00-07&endDate=2021-09-30T00%3A00%3A00-07&action=CREATE&action=EDIT&action=DELETE&component=SCHEDULED_PROJECT&userType=IMS&description=job&pageSize=2
+```
+Response:
+```
+{
+  "content": [
+    {
+      "id": "615559925e0e8a7da2152d86",
+      "dateCreated": "2021-09-30T06:30:42.968+00:00",
+      "action": "CREATE",
+      "description": "Creating scheduled job: ce4e1239-ab7b-471c-9d6a-14934c9d5ea4",
+      "imsOrgId": "4E9432245BC7C44B0A494037@AdobeOrg",
+      "user": {
+        "id": "434F42A85501C8190A4C86DE@AdobeID",
+        "idType": "IMS",
+        "name": null,
+        "email": null
+      },
+      "component": {
+        "id": "ce4e1239-ab7b-471c-9d6a-14934c9d5ea4",
+        "idType": "SCHEDULED_PROJECT",
+        "name": ""
+      }
+    },
+    {
+      "id": "615556df5e0e8a7da2152d85",
+      "dateCreated": "2021-09-30T06:19:11.145+00:00",
+      "action": "EDIT",
+      "description": "Updating scheduled job: 2dab1331-4844-4f82-94ff-9721ec47830c",
+      "imsOrgId": "4E9432245BC7C44B0A494037@AdobeOrg",
+      "user": {
+        "id": "039D6F286137B99D0A49401D@fd6f6f286137b98d494230.e",
+        "idType": "IMS",
+        "name": null,
+        "email": null
+      },
+      "component": {
+        "id": "2dab1331-4844-4f82-94ff-9721ec47830c",
+        "idType": "SCHEDULED_PROJECT",
+        "name": ""
+      }
+    }
+  ],
+  "pageable": {
+    "sort": {
+      "sorted": false,
+      "unsorted": true,
+      "empty": true
+    },
+    "offset": 0,
+    "pageNumber": 0,
+    "pageSize": 2,
+    "paged": true,
+    "unpaged": false
+  },
+  "last": false,
+  "totalElements": 1246,
+  "totalPages": 623,
+  "size": 2,
+  "number": 0,
+  "sort": {
+    "sorted": false,
+    "unsorted": true,
+    "empty": true
+  },
+  "numberOfElements": 2,
+  "first": true,
+  "empty": false
+}
+```
+
+## Search Audit Logs
+
+If you need to retrieve a list of audit logs using 'OR' criteria, you will want to utilize the POST /auditlogs/search endpoint. These lists can be used as a guide for the available ENUM values for the associated key.
+
+`POST https://cja.adobe.io/auditlogs/api/v1/auditlogs/search`
+
+
+### fieldType
+  * COMPONENT
+  * COMPONENT_ID
+  * USER
+  * USER_ID
+  * USER_EMAIL
+  * BEGIN_DATE_RANGE
+  * END_DATE_RANGE
+  * ACTION
+  * DESCRIPTION
+
+#### Notes
+
+_If 'BEGIN_DATE_RANGE' is set as a fieldType, 'END_DATE_RANGE' must also be set. These fieldTypes must use 'EQUALS' as their 'operator'._
+
+### operator
+
+* EQUALS
+* NOT_EQUALS
+* CONTAINS
+* IN
+
+### fieldOperator
+
+* AND
+* OR
+
+
+## POST Example 1
+
+#### Show me audit logs where the component is 'FILTER' or 'CALCULATED_METRIC', the 'DESCRIPTION' contains the string 'created', AND the 'USER_EMAIL' contains EITHER 'jane' or 'john'.
+
+```
+{
+  "criteria": {
+    "fieldOperator": "AND",
+    "fields": [
+      {
+        "fieldType": "COMPONENT",
+        "value": [
+          "FILTER",
+          "CALCULATED_METRIC"
+        ],
+        "operator": "IN"
+      },
+      {
+        "fieldType": "DESCRIPTION",
+        "value": [
+          "created"
+        ],
+        "operator": "CONTAINS"
+      }
+    ],
+    "subCriteriaOperator": "AND",
+    "subCriteria": {
+      "fieldOperator": "OR",
+      "fields": [
+        {
+          "fieldType": "USER_EMAIL",
+          "value": [
+            "jane"
+          ],
+          "operator": "CONTAINS"
+        },
+        {
+          "fieldType": "USER_EMAIL",
+          "value": [
+            "john"
+          ],
+          "operator": "CONTAINS"
+        }
+      ],
+      "subCriteriaOperator": null,
+      "subCriteria": null
+    }
+  },
+  "pageSize": 100,
+  "pageNumber": 0
+}
+```
+
+## POST Example 2
+
+#### Show me audit logs between June 1st and October 1st where the 'ACTION' was either 'CREATE' OR 'EDIT' OR the 'DESCRIPTION' contained the string 'job' or 'test'. The response will only include logs between those dates but the other criteria will be filtered using 'OR' logic.
+
+```
+{
+  "criteria": {
+    "fieldOperator": "AND",
+    "fields": [
+      {
+        "fieldType": "BEGIN_DATE_RANGE",
+        "value": [
+          "2021-06-01T00:00:00-07"
+        ],
+        "operator": "EQUALS"
+      },
+      {
+        "fieldType": "END_DATE_RANGE",
+        "value": [
+          "2021-10-01T00:00:00-07"
+        ],
+        "operator": "EQUALS"
+      }
+    ],
+    "subCriteriaOperator": "AND",
+    "subCriteria": {
+      "fieldOperator": "OR",
+      "fields": [
+        {
+          "fieldType": "ACTION",
+          "value": [
+            "CREATE",
+            "EDIT"
+          ],
+          "operator": "IN"
+        },
+          {
+          "fieldType": "DESCRIPTION",
+          "value": [
+            "job",
+            "test"
+          ],
+          "operator": "CONTAINS"
+        }
+      ],
+      "subCriteriaOperator": null,
+      "subCriteria": null
+    }
+  },
+  "pageSize": 10,
+  "pageNumber": 0
+}

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -13209,6 +13209,569 @@
           }
         }
       }
+    },
+    "/auditlogs/api/v1/auditlogs/search": {
+      "post": {
+        "tags": [
+          "Audit Logs"
+        ],
+        "summary": "Retrieve audit logs for Customer Journey Analytics.",
+        "description": "This API returns a filterable list of audit log records.",
+        "operationId": "searchAuditLogs_1",
+        "parameters": [
+          {
+            "name": "x-user-auth",
+            "in": "header",
+            "description": "IMS User Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-gw-ims-org-id",
+            "in": "header",
+            "description": "IMS Organization ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body containing the search criteria to filter the results by",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchDto"
+              },
+              "examples": {
+                "Do not apply any filters. Return audit log records sorted in descending order by date created.": {
+                  "summary": "Return the latest records. No filters applied.",
+                  "description": "Do not apply any filters. Return audit log records sorted in descending order by date created.",
+                  "value": {
+                    "criteria": null,
+                    "pageSize": 10,
+                    "pageNumber": 0
+                  }
+                },
+                "Another example of a valid request to not apply any filters. Return audit log records sorted in descending order by date created.": {
+                  "summary": "No filters.",
+                  "description": "Another example of a valid request to not apply any filters. Return audit log records sorted in descending order by date created.",
+                  "value": {}
+                },
+                "Filter audit logs between two dates where records have an 'ACTION' fieldType of 'CREATE' OR 'EDIT'.  ": {
+                  "summary": "Filter logs by date range where fieldType is 'x' or 'y'",
+                  "description": "Filter audit logs between two dates where records have an 'ACTION' fieldType of 'CREATE' OR 'EDIT'.  ",
+                  "value": {
+                    "criteria": {
+                      "fieldOperator": "AND",
+                      "fields": [
+                        {
+                          "fieldType": "BEGIN_DATE_RANGE",
+                          "value": [
+                            "2021-06-01T00:00:00-07"
+                          ],
+                          "operator": "EQUALS"
+                        },
+                        {
+                          "fieldType": "END_DATE_RANGE",
+                          "value": [
+                            "2021-07-30T23:59:59-07"
+                          ],
+                          "operator": "EQUALS"
+                        }
+                      ],
+                      "subCriteriaOperator": "AND",
+                      "subCriteria": {
+                        "fieldOperator": "AND",
+                        "fields": [
+                          {
+                            "fieldType": "ACTION",
+                            "value": [
+                              "CREATE",
+                              "EDIT"
+                            ],
+                            "operator": "IN"
+                          }
+                        ],
+                        "subCriteriaOperator": null,
+                        "subCriteria": null
+                      }
+                    },
+                    "pageSize": 10,
+                    "pageNumber": 0
+                  }
+                },
+                "Filter audit logs by component and description. Also filter logs where the user_email contains one user or another.  ": {
+                  "summary": "Filter logs by component, description and user email",
+                  "description": "Filter audit logs by component and description. Also filter logs where the user_email contains one user or another.  ",
+                  "value": {
+                    "criteria": {
+                      "fieldOperator": "AND",
+                      "fields": [
+                        {
+                          "fieldType": "COMPONENT",
+                          "value": [
+                            "DATA_VIEW",
+                            "DATA_GROUP",
+                            "CONNECTION"
+                          ],
+                          "operator": "IN"
+                        },
+                        {
+                          "fieldType": "DESCRIPTION",
+                          "value": [
+                            "created"
+                          ],
+                          "operator": "CONTAINS"
+                        }
+                      ],
+                      "subCriteriaOperator": "AND",
+                      "subCriteria": {
+                        "fieldOperator": "OR",
+                        "fields": [
+                          {
+                            "fieldType": "USER_EMAIL",
+                            "value": [
+                              "jane"
+                            ],
+                            "operator": "CONTAINS"
+                          },
+                          {
+                            "fieldType": "USER_EMAIL",
+                            "value": [
+                              "john"
+                            ],
+                            "operator": "CONTAINS"
+                          }
+                        ],
+                        "subCriteriaOperator": null,
+                        "subCriteria": null
+                      }
+                    },
+                    "pageSize": null,
+                    "pageNumber": null
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "500": {
+            "description": "Unexpected error; Searching audit logs failed due to an internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsAsrErrorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation errors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsAsrErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAuditLogDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auditlogs/api/v1/auditlogs": {
+      "get": {
+        "tags": [
+          "Audit Logs"
+        ],
+        "summary": "Get audit logs for Customer Journey Analytics.",
+        "description": "This API returns a filterable list of audit log records.",
+        "operationId": "getAuditLogs_1",
+        "parameters": [
+          {
+            "name": "x-user-auth",
+            "in": "header",
+            "description": "IMS User Access Token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-gw-ims-org-id",
+            "in": "header",
+            "description": "IMS Organization ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "description": "Date is not required, but if you filter by date, both start & end date must be set.",
+            "schema": {
+              "type": "string",
+              "default": "2021-08-01T00:00:00-07"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "description": "Date is not required, but if you filter by date, both start & end date must be set.",
+            "schema": {
+              "type": "string",
+              "default": "2021-08-31T00:00:00-07"
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "description": "The action you want to filter by.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "component",
+            "in": "query",
+            "description": "The type of component you want to filter by.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "componentId",
+            "in": "query",
+            "description": "The ID of the component.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userType",
+            "in": "query",
+            "description": "The type of user.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "The ID of the user.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userEmail",
+            "in": "query",
+            "description": "The email address of the user.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "description": "The log description you want to filter by.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of results per page. If left null, the default size will be set to 100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "description": "Page number (base 0 - first page is \"0\")",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "500": {
+            "description": "Unexpected error; Searching audit logs failed due to an internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsAsrErrorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation errors.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsAsrErrorResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserAuditLogDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "ComponentDto" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "idType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        }
+      },
+      "UserDto" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "idType" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Pageable" : {
+        "type" : "object",
+        "properties" : {
+          "sort" : {
+            "$ref" : "#/components/schemas/Sort"
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "paged" : {
+            "type" : "boolean"
+          },
+          "unpaged" : {
+            "type" : "boolean"
+          },
+          "offset" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
+      "Sort" : {
+        "type" : "object",
+        "properties" : {
+          "sorted" : {
+            "type" : "boolean"
+          },
+          "unsorted" : {
+            "type" : "boolean"
+          },
+          "empty" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "FieldDto" : {
+        "type" : "object",
+        "properties" : {
+          "fieldType" : {
+            "type" : "string",
+            "enum" : [ "COMPONENT", "COMPONENT_ID", "APPLICATION", "APPLICATION_ID", "USER", "USER_ID", "USER_EMAIL", "ORG_ID", "BEGIN_DATE_RANGE", "END_DATE_RANGE", "ACTION", "DESCRIPTION" ]
+          },
+          "value" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "operator" : {
+            "type" : "string",
+            "enum" : [ "EQUALS", "NOT_EQUALS", "CONTAINS", "IN" ]
+          }
+        }
+      },
+      "SearchCriteriaDto" : {
+        "type" : "object",
+        "properties" : {
+          "fieldOperator" : {
+            "type" : "string",
+            "enum" : [ "AND", "OR" ]
+          },
+          "fields" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/FieldDto"
+            }
+          },
+          "subCriteriaOperator" : {
+            "type" : "string",
+            "enum" : [ "AND", "OR" ]
+          },
+          "subCriteria" : {
+            "$ref" : "#/components/schemas/SearchCriteriaDto"
+          }
+        }
+      },
+      "SearchDto" : {
+        "type" : "object",
+        "properties" : {
+          "criteria" : {
+            "$ref" : "#/components/schemas/SearchCriteriaDto"
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "pageNumber" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "AnalyticsAsrErrorResponse" : {
+        "properties" : {
+          "errorDescription" : {
+            "type" : "string"
+          },
+          "errorCode" : {
+            "type" : "string"
+          },
+          "errorId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PageUserAuditLogDto" : {
+        "type" : "object",
+        "properties" : {
+          "totalElements" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "totalPages" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "sort" : {
+            "$ref" : "#/components/schemas/Sort"
+          },
+          "numberOfElements" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "first" : {
+            "type" : "boolean"
+          },
+          "last" : {
+            "type" : "boolean"
+          },
+          "pageable" : {
+            "$ref" : "#/components/schemas/Pageable"
+          },
+          "size" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "content" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserAuditLogDto"
+            }
+          },
+          "number" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "empty" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "UserAuditLogDto" : {
+        "properties" : {
+          "component" : {
+            "$ref" : "#/components/schemas/ComponentDto"
+          },
+          "dateCreated" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "action" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "user" : {
+            "$ref" : "#/components/schemas/UserDto"
+          },
+          "imsOrgId" : {
+            "type" : "string"
+          }
+        }
+      }
     }
   }
 }
+


### PR DESCRIPTION
There are two new CJA API endpoints being deployed to Adobe IO for audit logs. This is the documentation for those two endpoints.