### PR TITLE
AN-313116 made changes to date descriptions to include new limit to 3…

### DIFF
--- a/src/swagger.json
+++ b/src/swagger.json
@@ -13405,7 +13405,7 @@
           },
           "required": false
         },
-        "parameters" : [ 
+        "parameters" : [
         {
           "name": "locale",
           "in": "query",
@@ -14339,13 +14339,13 @@
           {
             "name": "startDate",
             "in": "query",
-            "description": "Date is not required, but if you filter by date, both start & end date must be set.",
+            "description": "Date is not required, but if you filter by date, both start & end date must be set. When date range is undefined, start date defaults to 3 months ago.",
             "schema": {}
           },
           {
             "name": "endDate",
             "in": "query",
-            "description": "Date is not required, but if you filter by date, both start & end date must be set.",
+            "description": "Date is not required, but if you filter by date, both start & end date must be set. When date range is undefined, end date defaults to today.",
             "schema": {}
           },
           {
@@ -14524,7 +14524,7 @@
           },
           "required": true
         },
-        "parameters" : [ 
+        "parameters" : [
         {
           "name": "locale",
           "in": "query",
@@ -14640,7 +14640,7 @@
           },
           "required": true
         },
-        "parameters" : [ 
+        "parameters" : [
         {
           "name": "id",
           "in": "path",
@@ -14765,7 +14765,7 @@
                 ]
               }
             }
-          }, 
+          },
           {
             "name": "locale",
             "in": "query",
@@ -14837,7 +14837,7 @@
                 ]
               }
             }
-          }, 
+          },
           {
             "name": "locale",
             "in": "query",
@@ -15003,7 +15003,7 @@
                 ]
               }
             }
-          }, 
+          },
           {
             "name": "locale",
             "in": "query",
@@ -15120,7 +15120,7 @@
                 ]
               }
             }
-          }, 
+          },
           {
             "name": "locale",
             "in": "query",


### PR DESCRIPTION
… months date range when left undefined

<!--- Provide a general summary of your changes in the Title above -->

## Description

src/swagger.json
Modified both start date and end date descriptions 

## Related Issue

https://jira.corp.adobe.com/browse/AN-313116

## Motivation and Context

It is required because if the user previously left those fields undefined, then you would get all data. Now we limit the data returned to the user when no start and end date are defined to 3 months of data. This avoids unintended hit to servers for data beyond what the user may have intended.

## How Has This Been Tested?

The change is limited to adding a sentence to the description field. 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
