### PR TITLE
AN-0 Add Forecasting related changes to reports endpoint

### DIFF
--- a/src/swagger.json
+++ b/src/swagger.json
@@ -5198,6 +5198,9 @@
                       "includeAnomalyDetection": {
                         "type": "boolean"
                       },
+                      "includeForecasting": {
+                        "type": "boolean"
+                      },
                       "includePercentChange": {
                         "type": "boolean"
                       },
@@ -7047,6 +7050,27 @@
                           "longitude": {
                             "type": "number",
                             "format": "double"
+                          },
+                          "dataForecasted": {
+                            "type": "array",
+                            "items": {
+                              "type": "number",
+                              "format": "double"
+                            }
+                          },
+                          "dataForecastedUpperBound": {
+                            "type": "array",
+                            "items": {
+                              "type": "number",
+                              "format": "double"
+                            }
+                          },
+                          "dataForecastedLowerBound": {
+                            "type": "array",
+                            "items": {
+                              "type": "number",
+                              "format": "double"
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
## Description
Added includeForecasting to RankedSettings in the request.

Added dataForecasted, dataForecastedUpperBound and dataForecastedLowerBound in the response. These will be populated for all rows corresponding to future dates if the request has includeForecasting enabled (Meaning this is forecasting request).

More info here:
https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=scservices&title=Data+Forecasting+in+CJA
## Checklist

- [x] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
