### PR TITLE
AN-387169: Configuration API path for getting all org user is changed…

### DIFF
--- a/static/swagger.json
+++ b/static/swagger.json
@@ -120,7 +120,7 @@
         }
       }
     },
-    "/configuration/org/users": {
+    "/configuration/orgs/users": {
       "get": {
         "tags": [
           "Configuration API"


### PR DESCRIPTION
… to "/orgs" instead of "/org".

It is to make API path consistent with other API paths.

Configuration API path for getting all org user is changed to "/orgs" instead of "/org


## Description

Configuration API path for getting all org user is changed to "/orgs" instead of "/org.
It is to make API path consistent with other API paths.

## Checklist

- [ ] I have reviewed and signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I have read and agree to the [CONTRIBUTING](CONTRIBUTING.md) document.
